### PR TITLE
Fix - Path Traversal Attack Vulnerability

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+openNDS (5.0.1)
+
+  * Fix - Path Traversal Attack vulnerability allowed by libmicrohttpd's built in unescape functionality [bluewavenet] [lynxis]
+
+ -- Rob White <dot@blue-wave.net> Wed, 06 May 2020 19:56:27 +0000
+
 openNDS (5.0.0)
 
   * Import - from NoDogSplash 4.5.0 allowing development without compromising NoDogSplash optimisation for minimum resource utilisation [bluewavenet]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openNDS (5.0.1-1) stable; urgency=medium
+
+  * Fix - Path Traversal Attack vulnerability allowed by libmicrohttpd's built in unescape functionality [bluewavenet] [lynxis]
+
+ -- Rob White <dot@blue-wave.net>  Wed, 06 May 2020 19:56:27 +0000
+
 openNDS (5.0.0-1) stable; urgency=medium
 
   * Import - from NoDogSplash 4.5.0 allowing development without compromising NoDogSplash optimisation for minimum resource utilisation [bluewavenet]

--- a/openwrt/opennds/Makefile
+++ b/openwrt/opennds/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
 PKG_HASH:= #shasum -a 256 of tar.gz of source files goes here
-PKG_BUILD_DIR:=$(BUILD_DIR)/opennds-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
 PKG_BUILD_PARALLEL:=1

--- a/openwrt/opennds/Makefile
+++ b/openwrt/opennds/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=5.0.0beta
+PKG_VERSION:=5.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?

--- a/src/conf.h
+++ b/src/conf.h
@@ -29,7 +29,7 @@
 #ifndef _CONF_H_
 #define _CONF_H_
 
-#define VERSION "5.0.0"
+#define VERSION "5.0.1"
 
 /*
  * Defines how many times should we try detecting the interface with the default route (in seconds).

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -342,6 +342,7 @@ libmicrohttpd_cb(void *cls,
 	t_client *client;
 	char ip[INET6_ADDRSTRLEN+1];
 	char mac[18];
+	char *dds = "../";
 	int rc = 0;
 
 	debug(LOG_DEBUG, "access: %s %s", method, url);
@@ -349,6 +350,12 @@ libmicrohttpd_cb(void *cls,
 	// only allow get
 	if (0 != strcmp(method, "GET")) {
 		debug(LOG_DEBUG, "Unsupported http method %s", method);
+		return send_error(connection, 403);
+	}
+
+	// block path traversal
+	if (strstr(url, dds) != NULL) {
+		debug(LOG_WARNING, "Probable Path Traversal Attack Detected - %s", url);
 		return send_error(connection, 403);
 	}
 


### PR DESCRIPTION
Fix - Path Traversal Attack vulnerability allowed by libmicrohttpd's built in unescape functionality. Thanks to @lynxis for informing the project.

Signed-off-by: Rob White `<rob@blue-wave.net>`