### PR TITLE
Deprecate legacy splash and other enhancements

### DIFF
--- a/forward_authentication_service/fas-aes/fas-aes-https.php
+++ b/forward_authentication_service/fas-aes/fas-aes-https.php
@@ -171,6 +171,7 @@ if (isset($_GET['fas']) and isset($_GET['iv']))  {
 		if ($name == "gatewayname") {$gatewayname=$value;}
 		if ($name == "tok") {$tok=$value;}
 		if ($name == "gatewayaddress") {$gatewayaddress=$value;}
+		if ($name == "gatewaymac") {$gatewaymac=$value;}
 		if ($name == "authdir") {$authdir=$value;}
 		if ($name == "originurl") {$originurl=$value;}
 		if ($name == "clientif") {$clientif=$value;}

--- a/forward_authentication_service/fas-aes/fas-aes.php
+++ b/forward_authentication_service/fas-aes/fas-aes.php
@@ -87,6 +87,7 @@ if (isset($_GET['fas']) and isset($_GET['iv']))  {
 		if ($name == "gatewayname") {$gatewayname=$value;}
 		if ($name == "tok") {$tok=$value;}
 		if ($name == "gatewayaddress") {$gatewayaddress=$value;}
+		if ($name == "gatewaymac") {$gatewaymac=$value;}
 		if ($name == "authdir") {$authdir=$value;}
 		if ($name == "originurl") {$originurl=$value;}
 		if ($name == "clientif") {$clientif=$value;}

--- a/openwrt/opennds/files/etc/config/opennds
+++ b/openwrt/opennds/files/etc/config/opennds
@@ -70,10 +70,17 @@ config opennds
 	option unescape_callback_enabled '0'
 	###########################################################################################
 
+	# Allow use of legacy html splash page
+	# Default '0'
+	# If set to '0' use of legacy html splash page is not allowed
+	# If set to '1' the legacy html splash page is allowed if FAS is not configured
+	#option allow_legacy_splash '0'
+	###########################################################################################
+
 	# WebRoot
 	# Default: /etc/opennds/htdocs
 	#
-	# The local path where the splash page content resides.
+	# The local path where the system css file, and legacy splash page content resides.
 	# ie. Serve the file splash.html from this directory
 	#option webroot '/etc/opennds/htdocs'
 	###########################################################################################
@@ -81,7 +88,7 @@ config opennds
 	# statuspage
 	# Default: status.html
 	#
-	# The page the client is show if the client is already authenticated but navigates to the captive portal.
+	# The page the client is shown if the client is already authenticated but navigates to the captive portal.
 	#
 	# option statuspage 'status.html'
 	###########################################################################################
@@ -90,7 +97,7 @@ config opennds
 	# splashpage
 	# Default: /etc/opennds/splash.html
 	#
-	# The html page used for templated splash page generation (if FAS/PreAuth is not enabled)
+	# The legacy html page used for templated splash page generation (if FAS/PreAuth is not enabled)
 	#
 	# splash.html displays a simplistic click to continue button.
 	#

--- a/openwrt/opennds/files/etc/init.d/opennds
+++ b/openwrt/opennds/files/etc/init.d/opennds
@@ -125,7 +125,7 @@ generate_uci_config() {
     walledgarden_fqdn_list walledgarden_port_list login_option_enabled use_outdated_mhd unescape_callback_enabled daemon \
     debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage \
-    redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
+    sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue trafficcontrol ratecheckwindow downloadrate uploadrate downloadquota uploadquota \
     syslogfacility ndsctlsocket fw_mark_authenticated \
     fw_mark_blocked fw_mark_trusted

--- a/openwrt/opennds/files/etc/init.d/opennds
+++ b/openwrt/opennds/files/etc/init.d/opennds
@@ -123,7 +123,7 @@ generate_uci_config() {
 
   for option in preauth binauth fasport faskey fasremotefqdn fasremoteip faspath fas_secure_enabled \
     walledgarden_fqdn_list walledgarden_port_list login_option_enabled use_outdated_mhd unescape_callback_enabled daemon \
-    debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
+    allow_legacy_splash debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage \
     sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue trafficcontrol ratecheckwindow downloadrate uploadrate downloadquota uploadquota \

--- a/resources/opennds.conf
+++ b/resources/opennds.conf
@@ -83,6 +83,13 @@ use_outdated_mhd 0
 unescape_callback_enabled 0
 ###########################################################################################
 
+# Allow use of legacy html splash page
+# Default 0
+# If set to 0 use of legacy html splash page is not allowed
+# If set to 1 the legacy html splash page is allowed if FAS is not configured
+# allow_legacy_splash 0
+###########################################################################################
+
 # Option: WebRoot
 # Default: /etc/openNDS/htdocs
 #

--- a/resources/opennds.conf
+++ b/resources/opennds.conf
@@ -173,7 +173,7 @@ FirewallRuleSet preauthenticated-users {
 #FirewallRule allow udp port 8020 to 112.122.123.124
 #
 #
-# This is the end of "FirewallRuleSet preauthenticated-users" section so wee need closing "}"
+# This is the end of "FirewallRuleSet preauthenticated-users" section so we need a closing "}"
 #
 }
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -904,10 +904,11 @@ config_read(const char *filename)
 			config.statuspage = safe_strdup(p1);
 			break;
 
-		// TODO: Deprecate RedirectURL
 		case oRedirectURL:
-			config.redirectURL = safe_strdup(p1);
-			debug(LOG_WARNING, "RedirectURL is now deprecated, please use FAS to provide this functionality");
+			// disable support for redirectURL
+			// TODO Remove code at later date
+			//config.redirectURL = safe_strdup(p1);
+			debug(LOG_ERR, "RedirectURL is no longer supported, please use FAS to provide this functionality");
 			break;
 		case oAuthIdleTimeout:
 			if (sscanf(p1, "%d", &config.auth_idle_timeout) < 1 || config.auth_idle_timeout < 0) {

--- a/src/conf.c
+++ b/src/conf.c
@@ -83,6 +83,7 @@ typedef enum {
 	oFasURL,
 	oFasSSL,
 	oLoginOptionEnabled,
+	oAllowLegacySplash,
 	oUseOutdatedMHD,
 	oUnescapeCallbackEnabled,
 	oFasSecureEnabled,
@@ -146,6 +147,7 @@ static const struct {
 	{ "fasurl", oFasURL },
 	{ "fasssl", oFasSSL },
 	{ "login_option_enabled", oLoginOptionEnabled },
+	{ "allow_legacy_splash", oAllowLegacySplash },
 	{ "use_outdated_mhd", oUseOutdatedMHD },
 	{ "unescape_callback_enabled", oUnescapeCallbackEnabled },
 	{ "fas_secure_enabled", oFasSecureEnabled },
@@ -229,6 +231,7 @@ config_init(void)
 	config.fas_port = DEFAULT_FASPORT;
 	config.fas_key = NULL;
 	config.login_option_enabled = DEFAULT_LOGIN_OPTION_ENABLED;
+	config.allow_legacy_splash = DEFAULT_ALLOW_LEGACY_SPLASH;
 	config.use_outdated_mhd = DEFAULT_USE_OUTDATED_MHD;
 	config.unescape_callback_enabled = DEFAULT_UNESCAPE_CALLBACK_ENABLED;
 	config.fas_secure_enabled = DEFAULT_FAS_SECURE_ENABLED;
@@ -806,6 +809,13 @@ config_read(const char *filename)
 			break;
 		case oLoginOptionEnabled:
 			if (sscanf(p1, "%d", &config.login_option_enabled) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(1);
+			}
+			break;
+		case oAllowLegacySplash:
+			if (sscanf(p1, "%d", &config.allow_legacy_splash) < 1) {
 				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
 				debug(LOG_ERR, "Exiting...");
 				exit(1);

--- a/src/conf.h
+++ b/src/conf.h
@@ -56,6 +56,7 @@
 #define DEFAULT_GATEWAYPORT 2050
 #define DEFAULT_FASPORT 0
 #define DEFAULT_LOGIN_OPTION_ENABLED 0
+#define DEFAULT_ALLOW_LEGACY_SPLASH 0
 #define DEFAULT_USE_OUTDATED_MHD 0
 #define DEFAULT_UNESCAPE_CALLBACK_ENABLED 0
 #define DEFAULT_FAS_SECURE_ENABLED 1
@@ -163,6 +164,7 @@ typedef struct {
 	unsigned int gw_port;			//@brief Port the webserver will run on
 	unsigned int fas_port;			//@brief Port the fas server will run on
 	int login_option_enabled;		//@brief Use default PreAuth Login script
+	int allow_legacy_splash;		//@brief Allow use of legacy html splash page
 	int use_outdated_mhd;			//@brief Use outdated libmicrohttpd
 	int unescape_callback_enabled;		//@brief Enable external MHD unescape callback script
 	int fas_secure_enabled;			//@brief Enable Secure FAS

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -980,7 +980,7 @@ iptables_fw_total_upload()
 	}
 
 	pclose(output);
-	debug(LOG_WARNING, "Can't find target %s in mangle table", CHAIN_OUTGOING);
+	debug(LOG_INFO, "Can't find target %s in mangle table", CHAIN_OUTGOING);
 	return 0;
 }
 
@@ -1018,7 +1018,7 @@ iptables_fw_total_download()
 	}
 
 	pclose(output);
-	debug(LOG_WARNING, "Can't find target %s in mangle table", CHAIN_INCOMING);
+	debug(LOG_INFO, "Can't find target %s in mangle table", CHAIN_INCOMING);
 	return 0;
 }
 

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -717,7 +717,7 @@ static int show_preauthpage(struct MHD_Connection *connection, const char *query
 		debug(LOG_DEBUG, "PreAuth: query: %s", query);
 	}
 
-	rc = execute_ret(msg, HTMLMAXSIZE - 1, "%s '%s' '%s'", config->preauth, enc_query, enc_user_agent);
+	rc = execute_ret(msg, HTMLMAXSIZE - 1, "%s '%s' '%s' '%d'", config->preauth, enc_query, enc_user_agent, config->login_option_enabled);
 
 	if (rc != 0) {
 		debug(LOG_WARNING, "Preauth script: %s '%s' - failed to execute", config->preauth, query);

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -988,12 +988,13 @@ static char *construct_querystring(t_client *client, char *originurl, char *quer
 	} else if (config->fas_secure_enabled == 2 || config->fas_secure_enabled == 3) {
 		get_client_interface(clientif, sizeof(clientif), client->mac);
 		snprintf(querystr, QUERYMAXLEN,
-			"clientip=%s%sclientmac=%s%sgatewayname=%s%stok=%s%sgatewayaddress=%s%sauthdir=%s%soriginurl=%s%sclientif=%s",
+			"clientip=%s%sclientmac=%s%sgatewayname=%s%stok=%s%sgatewayaddress=%s%sgatewaymac=%s%sauthdir=%s%soriginurl=%s%sclientif=%s",
 			client->ip, QUERYSEPARATOR,
 			client->mac, QUERYSEPARATOR,
 			config->gw_name, QUERYSEPARATOR,
 			client->token, QUERYSEPARATOR,
 			config->gw_address, QUERYSEPARATOR,
+			config->gw_mac, QUERYSEPARATOR,
 			config->authdir, QUERYSEPARATOR,
 			originurl, QUERYSEPARATOR,
 			clientif);


### PR DESCRIPTION
Deprecate legacy splash.html and disable it:

- Use login shell script with config select of "continue" or username/email login.
- Allow re-enabling (of splash.html) with allow_legacy_splash config option.

Add gatewaymac to the encrypted query string

Remove support for deprecated RedirectURL

