### PR TITLE
Add: Support for Custom Parameters

### DIFF
--- a/forward_authentication_service/libs/get_client_interface.sh
+++ b/forward_authentication_service/libs/get_client_interface.sh
@@ -86,7 +86,11 @@ if [ "$iwstatus" = true ]; then
 fi
 
 # Return the local interface the client is using, the mesh node mac address and the local mesh interface
-echo "$clientlocalif $clientmeshif"
+if [ -z "$clientmeshif" ]; then
+	printf "%s" "$clientlocalif"
+else
+	printf "%s" "$clientlocalif $clientmeshif"
+fi
 
 exit 0
 

--- a/openwrt/opennds/files/etc/init.d/opennds
+++ b/openwrt/opennds/files/etc/init.d/opennds
@@ -122,7 +122,8 @@ generate_uci_config() {
   addline "GatewayInterface $ifname"
 
   for option in preauth binauth fasport faskey fasremotefqdn fasremoteip faspath fas_secure_enabled \
-    walledgarden_fqdn_list walledgarden_port_list login_option_enabled use_outdated_mhd unescape_callback_enabled daemon \
+    walledgarden_fqdn_list walledgarden_port_list fas_custom_parameters_list\
+    login_option_enabled use_outdated_mhd unescape_callback_enabled daemon \
     allow_legacy_splash debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage \
     sessiontimeout preauthidletimeout authidletimeout checkinterval \

--- a/src/common.h
+++ b/src/common.h
@@ -32,8 +32,16 @@
 /* Max length of a query string in bytes */
 #define QUERYMAXLEN 4096
 
-/* Separator for Preauth query string */
+/* Separator for Preauth and Encrypted query string */
 #define QUERYSEPARATOR ", "
+
+/* Separator for html query string */
+#define HTMLQUERYSEPARATOR "&"
+
+// Define a custom separator for custom parameter name/value pairs ie urlencoded "="
+#define CUSTOM_SEPARATOR "%3d"
+#define FORMAT_SPECIFIER "%s"
+#define URL_COMMASPACE "%2c%20"
 
 /* Max dynamic html page size in bytes */
 #define HTMLMAXSIZE 4096

--- a/src/conf.h
+++ b/src/conf.h
@@ -145,6 +145,12 @@ typedef struct _WGFQDN_t {
 	struct _WGFQDN_t *next;
 } t_WGFQDN;
 
+// Custom FAS Parameters
+typedef struct _FASPARAM_t {
+	char *fasparam;
+	struct _FASPARAM_t *next;
+} t_FASPARAM;
+
 // Configuration structure
 typedef struct {
 	char configfile[255];			//@brief name of the config file
@@ -203,7 +209,9 @@ typedef struct {
 	t_MAC *blockedmaclist;			//@brief list of blocked macs
 	t_MAC *allowedmaclist;			//@brief list of allowed macs
 	t_WGP *walledgarden_port_list;		//@brief list of Walled Garden Ports
-	t_WGFQDN *walledgarden_fqdn_list;		//@brief list of Walled Garden FQDNs
+	t_WGFQDN *walledgarden_fqdn_list;	//@brief list of Walled Garden FQDNs
+	t_FASPARAM *fas_custom_parameters_list;	//@brief list of Custom FAS parameters
+	char *custom_params;			//@brief FAS custom parameter string
 	unsigned int fw_mark_authenticated;	//@brief iptables mark for authenticated packets
 	unsigned int fw_mark_blocked;		//@brief iptables mark for blocked packets
 	unsigned int fw_mark_trusted;		//@brief iptables mark for trusted packets
@@ -247,6 +255,7 @@ void parse_blocked_mac_list(const char[]);
 void parse_allowed_mac_list(const char[]);
 void parse_walledgarden_fqdn_list(const char[]);
 void parse_walledgarden_port_list(const char[]);
+void parse_fas_custom_parameters_list(const char[]);
 
 int is_blocked_mac(const char *mac);
 int is_allowed_mac(const char *mac);

--- a/src/main.c
+++ b/src/main.c
@@ -297,6 +297,24 @@ setup_from_config(void)
 		}
 	}
 
+	// Setup custom FAS parameters if configured
+	char fasparam[512] = {0};
+	t_FASPARAM *fas_fasparam;
+	if (config->fas_custom_parameters_list) {
+		for (fas_fasparam = config->fas_custom_parameters_list; fas_fasparam != NULL; fas_fasparam = fas_fasparam->next) {
+
+			// Make sure we don't have a buffer overflow
+			if ((sizeof(fasparam) - strlen(fasparam)) > (strlen(fas_fasparam->fasparam) + 4)) {
+				strcat(fasparam, QUERYSEPARATOR);
+				strcat(fasparam, fas_fasparam->fasparam);
+			} else {
+				break;
+			}
+		}
+			config->custom_params = safe_strdup(fasparam);
+		debug(LOG_NOTICE, "Custom FAS parameter string [%s]", config->custom_params);
+	}
+
 	// Check we have ipset support and if we do, set it up
 	if (config->walledgarden_fqdn_list) {
 		// Check ipset command is available


### PR DESCRIPTION
This enhancement allows custom parameters to be defined in the config file.

This enhancement is **added primarily to support remote configuration operations**
using tools such as opensync, but can also be of general use.

**Custom Parameters** are options defined in the configuration file
and _have fixed values_ once set.

**Note: Custom Variables are very different** and are defined in the FAS,
with values determined by the FAS/Client dialogue script.

Signed-off-by: Rob White <rob@blue-wave.net>