### PR TITLE
ndsctl: Fix ndsctl locking by using lockf()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ STRIP=yes
 
 NDS_OBJS=src/auth.o src/client_list.o src/commandline.o src/conf.o \
 	src/debug.o src/fw_iptables.o src/main.o src/http_microhttpd.o src/http_microhttpd_utils.o \
-	src/ndsctl_thread.o src/safe.o src/util.o
+	src/ndsctl_thread.o src/safe.o src/util.o src/ndsctl_lock.o
 
 .PHONY: all clean install
 
@@ -22,7 +22,7 @@ all: opennds ndsctl
 opennds: $(NDS_OBJS) $(LIBHTTPD_OBJS)
 	$(CC) $(LDFLAGS) -o opennds $+ $(LDLIBS)
 
-ndsctl: src/ndsctl.o
+ndsctl: src/ndsctl_lock.o src/ndsctl.o
 	$(CC) $(LDFLAGS) -o ndsctl $+ $(LDLIBS)
 
 clean:

--- a/src/conf.c
+++ b/src/conf.c
@@ -707,7 +707,6 @@ config_read(const char *filename)
 	struct stat sb;
 	char msg[128] = {0};
 	char *cmd = NULL;
-	char *lockfile;
 
 	safe_asprintf(&cmd, "/usr/lib/opennds/libopennds.sh clean");
 
@@ -719,16 +718,6 @@ config_read(const char *filename)
 	} else {
 		config.tmpfsmountpoint = safe_strdup(msg);
 	}
-
-	safe_asprintf(&lockfile, "%s/ndsctl.lock", config.tmpfsmountpoint);
-
-	//Remove ndsctl lock file if it exists
-	if ((fd = fopen(lockfile, "r")) != NULL) {
-		fclose(fd);
-		remove(lockfile);
-	}
-
-	free (lockfile);
 
 	debug(LOG_INFO, "Reading configuration file '%s'", filename);
 

--- a/src/ndsctl_lock.c
+++ b/src/ndsctl_lock.c
@@ -1,0 +1,66 @@
+/********************************************************************\
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 59 Temple Place - Suite 330        Fax:    +1-617-542-2652       *
+ * Boston, MA  02111-1307,  USA       gnu@gnu.org                   *
+ *                                                                  *
+ \********************************************************************/
+
+/**
+  @file ndsctl_lock.c
+  @brief ndsctl locking
+  @author Copyright (C) 2021 Linus Lüssing <ll@simonwunderlich.de>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+
+#define NDSCTL_LOCK_TIMEOUT_MS 1000
+
+int ndsctl_lock(const char *lockfile)
+{
+	int fd, i, ret;
+
+	fd = open(lockfile, O_RDWR | O_CREAT);
+	if (fd < 0)
+		return -1;
+
+	for (i = 0; i < NDSCTL_LOCK_TIMEOUT_MS; i++) {
+		ret = lockf(fd, F_TLOCK, 0);
+		if (ret == 0) {
+			return fd;
+		}
+
+		/* persistent error, no reason to retry */
+		if (errno != EACCES && errno != EAGAIN)
+			break;
+
+		/* sleep for 1ms */
+		usleep(1000);
+	}
+
+	close(fd);
+	return -1;
+}
+
+void ndsctl_unlock(int fd)
+{
+	lockf(fd, F_ULOCK, 0);
+	close(fd);
+}

--- a/src/ndsctl_lock.h
+++ b/src/ndsctl_lock.h
@@ -1,0 +1,32 @@
+/********************************************************************\
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 59 Temple Place - Suite 330        Fax:    +1-617-542-2652       *
+ * Boston, MA  02111-1307,  USA       gnu@gnu.org                   *
+ *                                                                  *
+\********************************************************************/
+
+/** @file ndsctl_lock.h
+    @brief ndsctl locking
+    @author Copyright (C) 2021 Linus Lüssing <ll@simonwunderlich.de>
+*/
+
+#ifndef _NDSCTL_LOCK_H_
+#define _NDSCTL_LOCK_H_
+
+int ndsctl_lock(const char *lockfile);
+void ndsctl_unlock(int fd);
+
+#endif


### PR DESCRIPTION
There are currently a few issues with the current locking approach:

For one thing, if ndsctl is terminated while it is running it will leave
a stale lock file which will lead to a failure of any subsequent ndsctl
invocation. Which can also lead to failing splash page access if the
example PreAuth script is used.

For another the moment in ndsctl or openNDS between checking if a lock
file exists and actually creating it can race with concurrent instances
trying to get/create this lock.

Furthermore when the lock is held by another instance instead of waiting
a brief moment for the lock to become free an error is displayed
instead. Which can lead to temporary failures of binauth, for example.

Instead an OS assisted locking mechanism should be used. Like lockf().
It has the following advantages:

When a process dies the lock is freed inderectly by the OS, as the
OS will automatically close the open file handle. And it is race free
regarding checking and obtaining the lock.

The deletion of the lock file is not necessary anymore and in fact
discouraged when using lockf(). As lockf() does not lock/unlock by
creating/removing the file but instead by using a POSIX lock on (a
section of) the file.

While switching to lockf() also adding retries. For up to one second
ndsctl or openNDS will check the availability of the lock file every
millisecond. And will exit with an error only after this one second
timeout.

This change (next to others) is also necessary to be able to run
multiple openNDS instances simultaneously later.

Signed-off-by: Linus Lüssing \<ll@simonwunderlich.de\>