### PR TITLE
linux_openwrt: Remove duplicate gateway interface parsing

### DIFF
--- a/linux_openwrt/opennds/files/etc/init.d/opennds
+++ b/linux_openwrt/opennds/files/etc/init.d/opennds
@@ -117,7 +117,7 @@ generate_uci_config() {
     walledgarden_fqdn_list walledgarden_port_list fas_custom_parameters_list fas_custom_variables_list \
     fas_custom_images_list fas_custom_files_list themespec_path\
     login_option_enabled use_outdated_mhd unescape_callback_enabled daemon \
-    debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
+    debuglevel maxclients gatewayname gatewayiprange \
     gatewayaddress gatewayport gatewayfqdn webroot \
     sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue ratecheckwindow downloadrate uploadrate downloadquota uploadquota \


### PR DESCRIPTION
A few lines earlier there is an explicit
'config_get ifname "$cfg" gatewayinterface' already. Which leads to
openNDS parsing this parameter twice, unnecessarilly. Fixing this by
removing a redundant one.

Signed-off-by: Linus Lüssing \<ll@simonwunderlich.de\>