### PR TITLE
linux_openwrt: add 'ifb' config option

### DIFF
--- a/linux_openwrt/opennds/files/etc/init.d/opennds
+++ b/linux_openwrt/opennds/files/etc/init.d/opennds
@@ -122,7 +122,7 @@ generate_uci_config() {
     sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue ratecheckwindow downloadrate uploadrate downloadquota uploadquota \
     syslogfacility ndsctlsocket fw_mark_authenticated \
-    fw_mark_blocked fw_mark_trusted
+    fw_mark_blocked fw_mark_trusted ifb
   do
     config_get val "$cfg" "$option"
 


### PR DESCRIPTION
The ifb option allows to specify an integer suffix for the ifb device.
Adding it to init script / UCI support.

Signed-off-by: Linus Lüssing \<ll@simonwunderlich.de\>