### PR TITLE
Fix quota + rate limits when switching to new account where disabled

### DIFF
--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -642,20 +642,10 @@ static int authenticate_client(struct MHD_Connection *connection,
 		client->session_end = (client->session_start + seconds);
 	}
 
-	if (downloadrate > 0) {
-		client->download_rate = downloadrate;
-	}
-	if (uploadrate > 0) {
-		client->upload_rate = uploadrate;
-	}
-
-	if (downloadquota > 0) {
-		client->download_quota = downloadquota;
-	}
-	if (uploadquota > 0) {
-		client->upload_quota = uploadquota;
-	}
-
+	client->download_rate = downloadrate;
+	client->upload_rate = uploadrate;
+	client->download_quota = downloadquota;
+	client->upload_quota = uploadquota;
 
 	// error checking
 	if (rc != 0) {


### PR DESCRIPTION
When a user first logs in to an account which has a rate limit or quota
and then logs in with a different account which does not have a rate
limit or quota then this setting will wrongly not be updated.

Instead always update these client settings with every new session.

Signed-off-by: Linus Lüssing \<ll@simonwunderlich.de\>