### PR TITLE
Fix - Prevent potential read overrun within the MHD page buffer

### DIFF
--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -766,7 +766,7 @@ static int authenticated(struct MHD_Connection *connection,
 
 	// User just entered gatewayaddress:gatewayport so give them the info page
 	if (strcmp(url, "/") == 0) {
-		msg = safe_malloc(HTMLMAXSIZE);
+		msg = safe_calloc(HTMLMAXSIZE);
 		rc = execute_ret(msg, HTMLMAXSIZE - 1, "%s '%s'", config->status_path, client->ip);
 
 		if (rc != 0) {
@@ -823,7 +823,7 @@ static int show_preauthpage(struct MHD_Connection *connection, const char *query
 		uh_urlencode(enc_query, sizeof(enc_query), query, strlen(query));
 		debug(LOG_DEBUG, "PreAuth: Encoded query: %s", enc_query);
 
-		msg = safe_malloc(HTMLMAXSIZE);
+		msg = safe_calloc(HTMLMAXSIZE);
 
 		safe_asprintf(&cmd, "%s '%s' '%s' '%d' '%s'", config->preauth, enc_query, enc_user_agent, config->login_option_enabled, config->themespec_path);
 		rc = execute_ret_url_encoded(msg, HTMLMAXSIZE - 1, cmd);

--- a/src/safe.c
+++ b/src/safe.c
@@ -36,6 +36,17 @@
 #include "safe.h"
 #include "debug.h"
 
+void * safe_calloc (size_t size)
+{
+	void * retval = NULL;
+	retval = calloc(1, size);
+	if (!retval) {
+		debug(LOG_CRIT, "Failed to calloc %d bytes of memory: %s. Bailing out.", size, strerror(errno));
+		exit(1);
+	}
+	return (retval);
+}
+
 void * safe_malloc (size_t size)
 {
 	void * retval = NULL;

--- a/src/safe.h
+++ b/src/safe.h
@@ -31,6 +31,9 @@
 #include <sys/types.h> /* For fork */
 #include <unistd.h> /* For fork */
 
+/** @brief Safe version of calloc
+ */
+void * safe_calloc (size_t size);
 
 /** @brief Safe version of malloc
  */


### PR DESCRIPTION
Random strings of characters could be output if the page size is set
much larger than the data in the page.
In some edge cases a segmentation fault could result.

Signed-off-by: Rob White <rob@blue-wave.net>