### PR TITLE
ndsctl: a few more command line parsing fixes (tested on 8.1.1 only)

### DIFF
--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -311,7 +311,7 @@ ndsctl_do(const char *socket, const struct argument *arg, const char *param)
 		return 3;
 	}
 
-	if (param) {
+	if (*param) {
 		snprintf(request, sizeof(request), "%s %s\r\n\r\n", arg->cmd, param);
 	} else {
 		snprintf(request, sizeof(request), "%s\r\n\r\n", arg->cmd);

--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -428,7 +428,10 @@ main(int argc, char **argv)
 	}
 
 	if (strcmp(argv[1], "-s") == 0) {
-		if (argc >= 2) {
+		// "ndsctl -s <mysock> cmd" => (argc == 4)
+		// check for "cmd", too, to avoid a segfault in
+		// find_argument() later
+		if (argc >= 4) {
 			socket = strdup(argv[2]);
 			i = 3;
 		} else {

--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -507,9 +507,9 @@ main(int argc, char **argv)
 	}
 
 	// Collect command line arguments then send the command
-	snprintf(args, sizeof(args), "%s", argv[i+1]);
+	if (argc > i+1) {
+		snprintf(args, sizeof(args), "%s", argv[i+1]);
 
-	if (argc > i) {
 		for (counter=i+2; counter < argc; counter++) {
 			snprintf(argi, sizeof(argi), ",%s", argv[counter]);
 			strncat(args, argi, sizeof(args)-1);


### PR DESCRIPTION
Hi,

I noticed that some fixing with 5168d17 for the "ndsctl json" command with a "-s" options was done already. I ran into similar issues on openNDS v8.1.1 and had made and tested a few patches on that (these patches in particular: 
https://github.com/T-X/openNDS/tree/8.1.1-pr-fix-ndsctl-json).

5168d17 looks fine to me, but I think there are three more bugs for the ndsctl command line parsing. I tried to rebase these remaining three issues to the master branch, but they aren't runtime tested. Let me know what you think about them.
