### PR TITLE
Increase cmd buffer length for longer interface names

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -376,7 +376,7 @@ char *
 get_iface_ip(const char ifname[], int ip6)
 {
 	char addrbuf[INET6_ADDRSTRLEN] = {0};
-	char cmd[128] = {0};
+	char cmd[256] = {0};
 	char iptype[8] = {0};
 	int i;
 


### PR DESCRIPTION
Modern interface names can be of the format wlxbcec231e88c2, which then break long executed commands.

The short buffer breaks for example executing the following command from `util.c` under Ubuntu 20.04:
```bash
ip address | grep -A2 ': wlxbcec231e88c2' | grep 'inet ' | awk '$NF == "wlxbcec231e88c2" {print $2}' | awk -F'/' 'NR==1 {printf $1}'
```
