### PR TITLE
Added required variable to FAS return string example

### DIFF
--- a/docs/source/fas.rst
+++ b/docs/source/fas.rst
@@ -185,7 +185,7 @@ Authentication Method for fas_secure_enabled levels 0,1 and 2
 
  This virtual URL is of the form:
 
- `http://[nds_ip]:[nds_port]/[authdir]/?tok=[token]&redir=[landing_page_url]`
+ `http://[nds_ip]:[nds_port]/[authdir]/?tok=[token]&redir=[landing_page_url]&custom=`
 
  This is most commonly achieved using an html form of method GET.
  The parameter redir can be the client's originally requested URL sent by NDS, or more usefully, the URL of a suitable landing page.


### PR DESCRIPTION
openNDS will trigger a kernel panic when

- using `fas_secure_enabled '1'`
- the rhid matches correctly
- the custom field is omitted

This was tested over 3 devices (GL iNET GL-AR750s, GL-AR750, GL-MT300N-V2) running stock OpenWRT 21.02.1 

If the field is actually optional, it would be necessary to check if nil in the code before referencing it.