### PR TITLE
Fix: Add missing mkdir command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ install:
 	cp linux_openwrt/opennds/files/etc/config/opennds $(DESTDIR)/etc/opennds/opennds.uci
 	cp resources/splash.css $(DESTDIR)/etc/opennds/htdocs/
 	cp resources/splash.jpg $(DESTDIR)/etc/opennds/htdocs/images/
+	mkdir -p $(DESTDIR)/etc/systemd/system
 	cp resources/opennds.service $(DESTDIR)/etc/systemd/system/
 	mkdir -p $(DESTDIR)/usr/lib/opennds
 	cp forward_authentication_service/binauth/binauth_log.sh $(DESTDIR)/usr/lib/opennds/


### PR DESCRIPTION
Hey,

This PR fixes a missing `mkdir` command in `Makefile`.

By the way:
We are currently working on packaging openNDS for Debian.
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009368

For the Debian package we will use `$(DESTDIR)/lib/systemd/system/` instead of `$(DESTDIR)/etc/systemd/system`.
Do you wish that I include this change in this PR too? 