### PR TITLE
linux_debian/doc/opennds.1: Fix typos in man page.

### DIFF
--- a/linux_debian/doc/opennds.1
+++ b/linux_debian/doc/opennds.1
@@ -156,7 +156,7 @@ Add \- spider remote urls before downloading [bluewavenet]
 .IP \(bu 2
 Add \- OpenWrt, revert uncommitted uci updates at startup and shutdown [bluewavenet]
 .IP \(bu 2
-Fix \- remove unneccesary flash writes and fix hosts updates [doctor\-ox] [bluewavenet]
+Fix \- remove unnecessary flash writes and fix hosts updates [doctor\-ox] [bluewavenet]
 .IP \(bu 2
 Add \- Updated splash images [bluewavenet]
 .IP \(bu 2
@@ -346,9 +346,9 @@ Add \- library call get_interface_by_ip [bluewavenet]
 .IP \(bu 2
 Add \- function encode_custom() for encoding custom data to be sent to openNDS [bluewavenet]
 .IP \(bu 2
-Fix \- error 511, make all html refrences absolute to enforce link to MHD [bluewavenet]
+Fix \- error 511, make all html references absolute to enforce link to MHD [bluewavenet]
 .IP \(bu 2
-Add \- check status_path exists and is executeable [bluewavenet]
+Add \- check status_path exists and is executable [bluewavenet]
 .IP \(bu 2
 Fix \- regression causing error 511 to be served from default script [bluewavenet]
 .IP \(bu 2
@@ -509,7 +509,7 @@ Fix \- some compiler warnings [bluewavenet]
 .IP \(bu 2
 Fix \- use configured value for webroot for remote image symlink to images folder [bluewavenet]
 .IP \(bu 2
-Fix \- remove refrences to login.sh in documentation and comments [bluewavenet]
+Fix \- remove references to login.sh in documentation and comments [bluewavenet]
 .IP \(bu 2
 Fix \- Prevent potential read overrun within the MHD page buffer [bluewavenet]
 .IP \(bu 2
@@ -779,7 +779,7 @@ openNDS (8.1.0)
 .IP \(bu 2
 This version introduces some new functionality and some fixes/enhancements
 .IP \(bu 2
-Fix \- Add default values for gatewayfqdn. If not set in config could result in crash on conection of first client [bluewavenet]
+Fix \- Add default values for gatewayfqdn. If not set in config could result in crash on connection of first client [bluewavenet]
 .IP \(bu 2
 Add \- Authenticated users are now granted access to the router by entry in "list authenticated_users" [bluewavenet]
 .IP \(bu 2
@@ -2651,7 +2651,7 @@ PreAuth support allows FAS to call a local program or script with html served by
 .sp
 If the option is set, it points to a program/script that is called by the NDS FAS handler.
 .sp
-All other FAS settings will be overidden.
+All other FAS settings will be overridden.
 .sp
 Example:
 .sp
@@ -4436,7 +4436,7 @@ arg2: contains the pid of the daemon to stop
 .UNINDENT
 .UNINDENT
 .sp
-\fIreturns\fP: "done" if sucessful or "nack" with exit code 1 if unsuccessful
+\fIreturns\fP: "done" if successful or "nack" with exit code 1 if unsuccessful
 .UNINDENT
 .UNINDENT
 .SS get_interface_by_ip:
@@ -5322,7 +5322,7 @@ git commit \-am "my change"
 .UNINDENT
 .UNINDENT
 .sp
-Now create a symbolic link in the openNDS package folder using the abolute path:
+Now create a symbolic link in the openNDS package folder using the absolute path:
 .INDENT 0.0
 .INDENT 3.5
 .sp


### PR DESCRIPTION
This PR fixes some typos in the man page.