### PR TITLE
Update - Mention TCP port 80 requires Autonomous Walled Garden

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1106,9 +1106,11 @@ This can be problematic as sites can use many dynamic ip addresses.
 
 However, manual configuration does not require any additional dependencies (ie additional installed packages).
 
-Manual configuration example:
+Note that standard unencrypted HTTP port (TCP port 80) is used for captive portal detection (CPD) and 
+access to external websites should use HTTPS (TCP port 443) for security. 
+It is still possible to allow TCP port 80 by using Autonomous Walled Garden approach.
 
-``list preauthenticated_users 'allow tcp port 80 to 112.122.123.124'``
+Manual configuration example:
 
 ``list preauthenticated_users 'allow udp port 8020 to 112.122.123.124'``
 

--- a/docs/source/walledgarden.rst
+++ b/docs/source/walledgarden.rst
@@ -12,6 +12,10 @@ Access to other web sites may be manually granted so clients can be served conte
 
 A set of such web sites is referred to as a Walled Garden.
 
+Note that standard unencrypted HTTP port (TCP port 80) is used for captive portal detection (CPD) and 
+access to external websites should use HTTPS (TCP port 443) for security.
+It is still possible to allow TCP port 80 by using Autonomous Walled Garden approach.
+
 Autonomous Walled Garden
 ************************
 

--- a/linux_openwrt/opennds/files/etc/config/opennds
+++ b/linux_openwrt/opennds/files/etc/config/opennds
@@ -775,11 +775,14 @@ config opennds
 	#####
 	# Manual Walled Garden configuration requires research to determine the ip addresses of the Walled Garden site(s)
 	# This can be problematic as sites can use many dynamic ip addresses.
-	# However, manual configuration does not require any additional dependencies (ie additional installed packages)
+	# However, manual configuration does not require any additional dependencies (ie additional installed packages).
+	#
+	# Note that standard unencrypted HTTP port (TCP port 80) is used for captive portal detection (CPD) and 
+	# access to external websites should use HTTPS (TCP port 443) for security.
+	# It is still possible to allow TCP port 80 by using Autonomous Walled Garden approach.
 	#
 	# Manual configuration example:
 	#
-	#list preauthenticated_users 'allow tcp port 80 to 112.122.123.124'
 	#list preauthenticated_users 'allow udp port 8020 to 112.122.123.124'
 	#
 


### PR DESCRIPTION
Standard unencrypted HTTP port (TCP port 80) requires Autonomous Walled Garden.

Resolves #396