### PR TITLE
Support specifying DHCP leases file location

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -183,6 +183,16 @@ The file must be flagged as executable and have the correct shebang for the defa
 
 ``option themespec_path '/usr/lib/opennds/<filename>'``
 
+DHCP Leases File
+****************
+
+Default: Try /tmp/dhcp.leases, /var/lib/misc/dnsmasq.lease or /var/db/dnsmasq.leases
+
+The file containing the list of active DHCP leases.
+
+Example:
+
+``option dhcp_leases_file '/tmp/dhcp.leases.special'``
 
 Define Custom Parameters
 ************************

--- a/forward_authentication_service/libs/libopennds.sh
+++ b/forward_authentication_service/libs/libopennds.sh
@@ -1121,7 +1121,15 @@ check_gw_ip() {
 }
 
 dhcp_check() {
-	dhcpdblocations="/tmp/dhcp.leases /var/lib/misc/dnsmasq.leases /var/db/dnsmasq.leases"
+	option="dhcp_leases_file"
+	get_option_from_config
+
+	if [ -z "$dhcp_leases_file" ] ; then
+		dhcpdblocations="/tmp/dhcp.leases /var/lib/misc/dnsmasq.leases /var/db/dnsmasq.leases"
+	else
+		dhcpdblocations="$dhcp_leases_file"
+	fi
+
 	dhcprecord=""
 	dbfile="no"
 

--- a/linux_openwrt/opennds/files/etc/config/opennds
+++ b/linux_openwrt/opennds/files/etc/config/opennds
@@ -102,6 +102,15 @@ config opennds
 	#option themespec_path '/usr/lib/opennds/<filename>'
 	###########################################################################################
 
+	# Custom DHCP Leases File Location
+	# Default: Try /tmp/dhcp.leases, /var/lib/misc/dnsmasq.lease or /var/db/dnsmasq.leases
+	#
+	# This allows setting a custom path to the DHCP leases file and is useful if the path has been changed or when using
+	# multiple instances of DNSmasq where more than one DHCP leases file may be required.
+	#
+	#option dhcp_leases_file '/tmp/dhcp.leases.special'
+	###########################################################################################
+
 	# Define Custom Parameters
 	# Custom parameters are sent as fixed values to FAS
 	# Default None


### PR DESCRIPTION
This change adds support for specifying a DHCP leases file location (.e.g: `/tmp/dhcp.leases.custom`) and is useful when the DHCP server instance that OpenNDSis associated with is using a custom location. Without the option specified OpenNDS will try `/tmp/dhcp.leases`,  `/var/lib/misc/dnsmasq.leases` and  `/var/db/dnsmasq.leases` in order.

Fixes #547