### PR TITLE
src/{main,auth,fw_iptables}.c: Evaluate system() calls' return values.

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -303,13 +303,17 @@ fw_refresh_client_list(void)
 	// If Walled Garden ipset exists, copy it to the nftset.
 	dnscmd = safe_calloc(STATUS_BUF);
 	safe_snprintf(dnscmd, STATUS_BUF, "/usr/lib/opennds/dnsconfig.sh \"ipset_to_nftset\" \"walledgarden\" %d &", config->checkinterval);
-	system(dnscmd);
+	if (system(dnscmd) != 0) {
+		debug(LOG_ERR, "failure: %s", dnscmd);
+	}
 	free(dnscmd);
 
 	// If Block List ipset exists, copy it to the nftset.
 	dnscmd = safe_calloc(STATUS_BUF);
 	safe_snprintf(dnscmd, STATUS_BUF, "/usr/lib/opennds/dnsconfig.sh \"ipset_to_nftset\" \"blocklist\" %d &", config->checkinterval);
-	system(dnscmd);
+	if (system(dnscmd) != 0) {
+		debug(LOG_ERR, "failure: %s", dnscmd);
+	}
 	free(dnscmd);
 
 	if (routercheck > 0) {
@@ -693,7 +697,9 @@ fw_refresh_client_list(void)
 		// Refresh preemptivemacs
 		pmaccmd = safe_calloc(STATUS_BUF);
 		safe_snprintf(pmaccmd, STATUS_BUF, "/usr/lib/opennds/libopennds.sh preemptivemac");
-		system(pmaccmd);
+		if (system(pmaccmd) != 0) {
+			debug(LOG_ERR, "failure: %s", pmaccmd);
+		}
 		free(pmaccmd);
 	}
 }

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -402,8 +402,11 @@ iptables_fw_init(void)
 	dnscmd = safe_calloc(STATUS_BUF);
 	safe_snprintf(dnscmd, STATUS_BUF, "/usr/lib/opennds/dnsconfig.sh \"reload_only\"");
 	debug(LOG_DEBUG, "reload command [ %s ]", dnscmd);
-	system(dnscmd);
-	debug(LOG_INFO, "Dnsmasq reloaded");
+	if (system(dnscmd) == 0) {
+		debug(LOG_INFO, "Dnsmasq reloaded");
+	} else {
+		debug(LOG_ERR, "Dnsmasq reload failed!");
+	}
 	free(dnscmd);
 
 	free(gw_interface);


### PR DESCRIPTION
This avoids these build warnings:


```
  src/fw_iptables.c: In function ‘iptables_fw_init’:
  src/fw_iptables.c:412:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    412 |         system(dnscmd);
        |         ^~~~~~~~~~~~~~
  src/auth.c: In function ‘fw_refresh_client_list’:
  src/auth.c:306:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    306 |         system(dnscmd);
        |         ^~~~~~~~~~~~~~
  src/auth.c:312:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    312 |         system(dnscmd);
        |         ^~~~~~~~~~~~~~
  src/auth.c:696:17: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    696 |                 system(pmaccmd);
        |                 ^~~~~~~~~~~~~~~
  src/main.c: In function ‘termination_handler’:
  src/main.c:210:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    210 |         system(dnscmd);
        |         ^~~~~~~~~~~~~~
  src/main.c: In function ‘main_loop’:
  src/main.c:930:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    930 |         system(cmd);
        |         ^~~~~~~~~~~
  src/main.c: In function ‘setup_from_config’:
  src/main.c:519:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    519 |         system(dnscmd);
        |         ^~~~~~~~~~~~~~
  src/main.c:722:17: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    722 |                 system(fasssl);
        |                 ^~~~~~~~~~~~~~
  src/main.c:754:25: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    754 |                         system(fasssl);
        |                         ^~~~~~~~~~~~~~
  src/main.c:882:9: warning: ignoring return value of ‘system’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    882 |         system(dnscmd);
        |         ^~~~~~~~~~~~~~
```