### PR TITLE
Update file path for login_option_enabled '2'

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -171,7 +171,7 @@ Required when when login_option_enabled is set to '3'
 
 Note: /usr/lib/opennds/theme_click-to-continue.sh is used for login_option_enabled '1'
 
-and:  /usr/lib/opennds/theme_user_email_login.sh is used for login_option_enabled '2'
+and:  /usr/lib/opennds/theme_user-email-login-basic.sh is used for login_option_enabled '2'
 
 Sets the ThemeSpec file path to be used when login_option_enabled '3'
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -169,7 +169,7 @@ Default: None
 
 Required when when login_option_enabled is set to '3'
 
-Note: /usr/lib/opennds/theme_click-to-continue.sh is used for login_option_enabled '1'
+Note: /usr/lib/opennds/theme_click-to-continue-basic.sh is used for login_option_enabled '1'
 
 and:  /usr/lib/opennds/theme_user-email-login-basic.sh is used for login_option_enabled '2'
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -117,7 +117,7 @@ User clicks on "Continue" are recorded in the log file /[tmpfs_dir]/ndslog/ndslo
 Where [tmpfs_dir] is the operating system "temporary" tmpfs mount point.
 This will be  /tmp /run or /var and is automatically detected.
 
-Details of how the script works are contained in comments in the script theme_click-to-continue.sh
+Details of how the script works are contained in comments in the script theme_click-to-continue-basic.sh
 
 
 Pre-Installed dynamic User/email Login page sequence
@@ -133,7 +133,7 @@ User logins are recorded in the log file /[tmpfs_dir]/ndslog/ndslog.log
 Where [tmpfs_dir] is the operating system "temporary" tmpfs mount point.
 This will be  /tmp /run or /var and is automatically detected.
 
-Details of how the script works are contained in comments in the script theme_user-email-login.sh
+Details of how the script works are contained in comments in the script theme_user-email-login-basic.sh
 
 
 Custom Dynamic ThemeSpec Pages

--- a/docs/source/themespec.rst
+++ b/docs/source/themespec.rst
@@ -20,9 +20,9 @@ and
 
 ``option login_option_enabled '2'`` (for username/email login)
 
-Mode 1 selects the script file theme_click-to-continue.sh for inclusion.
+Mode 1 selects the script file theme_click-to-continue-basic.sh for inclusion.
 
-Mode 2 selects the script file theme_user-email-login.sh for inclusion.
+Mode 2 selects the script file theme_user-email-login-basic.sh for inclusion.
 
 Automated Content Updates
 -------------------------

--- a/linux_openwrt/opennds/files/etc/config/opennds
+++ b/linux_openwrt/opennds/files/etc/config/opennds
@@ -88,7 +88,7 @@ config opennds
 	# Default: None
 	# Required when when login_option_enabled is set to '3'
 	#
-	# Note: /usr/lib/opennds/theme_click-to-continue.sh is used for login_option_enabled '1'
+	# Note: /usr/lib/opennds/theme_click-to-continue-basic.sh is used for login_option_enabled '1'
 	# and:  /usr/lib/opennds/theme_user-email-login-basic.sh is used for login_option_enabled '2'
 	#
 	# Sets the ThemeSpec file path to be used when login_option_enabled '3'

--- a/linux_openwrt/opennds/files/etc/config/opennds
+++ b/linux_openwrt/opennds/files/etc/config/opennds
@@ -89,7 +89,7 @@ config opennds
 	# Required when when login_option_enabled is set to '3'
 	#
 	# Note: /usr/lib/opennds/theme_click-to-continue.sh is used for login_option_enabled '1'
-	# and:  /usr/lib/opennds/theme_user_email_login.sh is used for login_option_enabled '2'
+	# and:  /usr/lib/opennds/theme_user-email-login-basic.sh is used for login_option_enabled '2'
 	#
 	# Sets the ThemeSpec file path to be used when login_option_enabled '3'
 	#


### PR DESCRIPTION
The file path for login_option_enabled '2' has been updated in both the config.rst and opennds config files. The new path points to the script 'theme_user-email-login-basic.sh' instead of 'theme_user_email_login.sh'.

View: forward_authentication_service/libs/libopennds.sh:409