### PR TITLE
Fix - Incorrect AES-256 key used

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -929,11 +929,11 @@ Default: A system generated sha256 string
 
 A key phrase for NDS to encrypt the query string sent to FAS.
 
-Can be any text string with no white space.
+Should be a 64-character hexadecimal string
 
-Hint and Example: Choose a secret string and use sha256sum utility to generate a hash.
+Hint and Example: Generate a 32-byte random number and convert it to a hexadecimal string.
 
-eg. Use the command - `echo "mysecretopenNDSfaskey" | sha256sum`
+eg. Use the command - `hexdump -v -n32 -e '32/1 "%02x" "\n"' /dev/urandom`
 
 Option faskey must be pre-shared with FAS. (It is automatically pre-shared with Themespec files)
 

--- a/docs/source/fas.rst
+++ b/docs/source/fas.rst
@@ -360,7 +360,7 @@ Assuming you have installed your web server of choice, configured it for port 20
 
     ``option fas_secure_enabled '2'``
 
-    ``option faskey 'your_secret_hashed_key_string'``
+    ``option faskey 'your_secret_key_hex_string'``
 
  * Restart NDS using the command ``service opennds restart``
 
@@ -388,7 +388,7 @@ Assuming you have access to an Internet based https web server you can do the fo
 
     ``option fas_secure_enabled '3'``
 
-    ``option faskey 'your_secret_hashed_key_string'``
+    ``option faskey 'your_secret_key_hex_string'``
 
     ``option fasremoteip '46.32.240.41'`` (change this to the actual ip address of the remote server)
 
@@ -427,7 +427,7 @@ Assuming you have access to an Internet based http web server you can do the fol
 
     ``option fas_secure_enabled '1'``
 
-    ``option faskey 'your_secret_hashed_key_string'``
+    ``option faskey 'your_secret_key_hex_string'``
 
     ``option fasremoteip '46.32.240.41'`` (change this to the actual ip address of the remote server)
 

--- a/forward_authentication_service/fas-aes/fas-aes-https.php
+++ b/forward_authentication_service/fas-aes/fas-aes-https.php
@@ -234,7 +234,7 @@ function decrypt_parse() {
 	if (isset($_GET['fas']) and isset($_GET['iv']))  {
 		$string=$_GET['fas'];
 		$iv=$_GET['iv'];
-		$decrypted=openssl_decrypt( base64_decode( $string ), $cipher, $GLOBALS["key"], 0, $iv );
+		$decrypted=openssl_decrypt( base64_decode( $string ), $cipher, hex2bin( $GLOBALS["key"] ), 0, $iv );
 		$dec_r=explode(", ",$decrypted);
 
 		foreach ($ndsparamlist as $ndsparm) {

--- a/forward_authentication_service/fas-aes/fas-aes.php
+++ b/forward_authentication_service/fas-aes/fas-aes.php
@@ -109,7 +109,7 @@ $ndsparamlist=explode(" ", "clientip clientmac client_type gatewayname gatewayur
 if (isset($_GET['fas']) and isset($_GET['iv']))  {
 	$string=$_GET['fas'];
 	$iv=$_GET['iv'];
-	$decrypted=openssl_decrypt( base64_decode( $string ), $cipher, $key, 0, $iv );
+	$decrypted=openssl_decrypt( base64_decode( $string ), $cipher, hex2bin( $key ), 0, $iv );
 	$dec_r=explode(", ",$decrypted);
 
 	foreach ($ndsparamlist as $ndsparm) {

--- a/forward_authentication_service/libs/libopennds.sh
+++ b/forward_authentication_service/libs/libopennds.sh
@@ -3201,9 +3201,7 @@ elif [ "$1" = "is_nodog" ]; then
 
 elif [ "$1" = "generate_key" ]; then
 	# Generate a key
-	k1=$(date | sha256sum | awk '{printf "%s", $1}')
-	k2=$(tr -cd "[:digit:]" < /dev/urandom | head -c 64 | sha256sum)
-	printf "$k1$k2" | sha256sum | awk -F' ' '{printf $1}'
+	hexdump -v -n32 -e '32/1 "%02x" "\n"' /dev/urandom
 
 	exit 0
 

--- a/linux_openwrt/opennds/files/etc/config/opennds
+++ b/linux_openwrt/opennds/files/etc/config/opennds
@@ -631,9 +631,9 @@ config opennds
 	# Option: faskey
 	# Default: A system generated sha256 string
 	# A key phrase for NDS to encrypt the query string sent to FAS
-	# Can be any text string with no white space
-	# Hint and Example: Choose a secret string and use sha256sum utility to generate a hash.
-	# eg. Use the command - echo "secret key" | sha256sum
+	# Should be a 64-character hexadecimal string
+	# Hint and Example: Generate a 32-byte random number and convert it to a hexadecimal string.
+	# eg. Use the command - `hexdump -v -n32 -e '32/1 "%02x" "\n"' /dev/urandom`
 	# Option faskey must be pre-shared with FAS.
 	#
 	#option faskey '328411b33fe55127421fa394995711658526ed47d0affad3fe56a0b3930c8689'

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -1630,7 +1630,7 @@ static char *construct_querystring(struct MHD_Connection *connection, t_client *
 			"if (in_array($cipher, openssl_get_cipher_methods())) {\n"
 				"$secret_iv = base64_encode(openssl_random_pseudo_bytes(\"8\"));\n"
 				"$iv = substr(openssl_digest($secret_iv, \"sha256\"), 0, 16 );\n"
-				"$string = base64_encode( openssl_encrypt( $string, $cipher, $key, 0, $iv ) );\n"
+				"$string = base64_encode( openssl_encrypt( $string, $cipher, hex2bin( $key ), 0, $iv ) );\n"
 				"echo \"?fas=\".$string.\"&iv=\".$iv;\n"
 			"}\n"
 			" ?>' "


### PR DESCRIPTION
The key length for AES-256 should be 256 bits (32 bytes). PHP's `openssl_encrypt` and `openssl_decrypt` functions accept a 32-byte string as the key,
and it will silently truncate the key if it exceeds this length. Therefore, the fas key should be changed to use a
32-byte string represented in hexadecimal format.