### PR TITLE
Fix - Remove escaped quotes in user agent field for compliance with RFC9110 

### DIFF
--- a/forward_authentication_service/libs/libopennds.sh
+++ b/forward_authentication_service/libs/libopennds.sh
@@ -1970,7 +1970,7 @@ wget_request () {
 	payload=$ndsctlout
 
 	webget
-	retval=$($wret -O - -U "\"$user_agent\"" "$url?auth_get=$action&gatewayhash=$gatewayhash&payload=$payload")
+	retval=$($wret -O - -U "$user_agent" "$url?auth_get=$action&gatewayhash=$gatewayhash&payload=$payload")
 	status=$?
  
 	if [ $status -ne 0 ]; then


### PR DESCRIPTION
Cloudflare WAF automatically blocks with error 403 when the user ager field is submitted  as a quoted string.