### PR TITLE
Add - preauthenticated_fqdn_list: mark-conditional FQDN access for preauthenticated clients

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 opennds (11.0.0)
+  * Add - preauthenticated_fqdn_list: mark-conditional FQDN access for preauthenticated clients
+  * Add - preauthenticated_port_list: port restriction for preauthenticated FQDN access
+  * Add - FW_MARK_PREAUTHENTICATED (0x10000): activate unused mark for preauthenticated state
+  * Add - iptables_fw_preauthenticate(): set mark when client enters preauthenticated state
+  * Add - mark-conditional nftset rule in libopennds.sh for preauthenticated nftset
+  * Fix - walledgarden CPD interference: preauthenticated domains no longer break Android CPD
   * Add - ipv6 support [bluewavenet]
   * Fix - MHD version check rework [mcassaniti]
   * Add - use library function to write to syslog [bluewavenet]

--- a/forward_authentication_service/libs/libopennds.sh
+++ b/forward_authentication_service/libs/libopennds.sh
@@ -1506,7 +1506,12 @@ nft_set () {
 			fi
 
 			if [ -z "$ports" ]; then
-				nft $nftsetmode rule inet nds_filter ndsNET counter ip daddr "@$nftsetname" "$nftruletype"
+				if [ "$nftsetname" = "preauthenticated" ]; then
+					# Mark-conditional rule: only matches clients with preauthenticated mark (0x10000)
+					nft $nftsetmode rule inet nds_filter ndsNET meta mark and 0x00010000 == 0x00010000 counter ip daddr "@$nftsetname" "$nftruletype"
+				else
+					nft $nftsetmode rule inet nds_filter ndsNET counter ip daddr "@$nftsetname" "$nftruletype"
+				fi
 
 			else
 				numports=$(echo $ports | tr -d "'" | awk '{printf NF}')
@@ -1515,7 +1520,12 @@ nft_set () {
 					ports=$(printf "$ports" | tr -d "'" | tr -s " " ",")
 				fi
 
-				nft $nftsetmode rule inet nds_filter ndsNET counter ip daddr "@$nftsetname" tcp dport {"$ports"} "$nftruletype"
+				if [ "$nftsetname" = "preauthenticated" ]; then
+					# Mark-conditional rule: only matches clients with preauthenticated mark (0x10000)
+					nft $nftsetmode rule inet nds_filter ndsNET meta mark and 0x00010000 == 0x00010000 counter ip daddr "@$nftsetname" tcp dport {"$ports"} "$nftruletype"
+				else
+					nft $nftsetmode rule inet nds_filter ndsNET counter ip daddr "@$nftsetname" tcp dport {"$ports"} "$nftruletype"
+				fi
 			fi
 
 
@@ -3190,9 +3200,9 @@ elif [ "$1" = "ipt_to_nft" ]; then
 	exit $ret
 
 elif [ "$1" = "nftset" ]; then
-	# Creates walledgarden or blocklist nftset
+	# Creates walledgarden, preauthenticated or blocklist nftset
 	# $2 is add, insert or delete the rule
-	# $3 is the nftset name
+	# $3 is the nftset name (walledgarden, preauthenticated or blocklist)
 	# $4 is the rule type (accept, drop or reject)
 
 	if [ -z "$2" ]; then
@@ -3218,6 +3228,8 @@ elif [ "$1" = "nftset" ]; then
 
 	if [ "$3" = "walledgarden" ] && [ "$nftruletype" = "accept" ]; then
 		nftsetname="walledgarden"
+	elif [ "$3" = "preauthenticated" ] && [ "$nftruletype" = "accept" ]; then
+		nftsetname="preauthenticated"
 	elif [ "$3" = "blocklist" ]; then
 		nftsetname="blocklist"
 

--- a/linux_openwrt/opennds/files/etc/config/opennds
+++ b/linux_openwrt/opennds/files/etc/config/opennds
@@ -855,6 +855,53 @@ config opennds 'setup'
 	###########################################################################################
 
 	#####
+	# Preauthenticated FQDN List
+	# Allow preauthenticated users to access external services using FQDN-based access control
+	#
+	# This is similar to the Walled Garden but with an important distinction:
+	#
+	# Walled Garden domains are accessible to ALL clients, including those that have not yet
+	# triggered Captive Portal Detection (CPD). This means adding domains like google.com to
+	# the Walled Garden can defeat CPD on Android and other devices.
+	#
+	# The Preauthenticated FQDN List uses the same nftset/dnsmasq infrastructure as the Walled
+	# Garden, but its ndsNET rule is MARK-CONDITIONAL. Access is only granted to clients that
+	# have entered the preauthenticated state (i.e. CPD has already triggered and the client
+	# has been assigned the preauthenticated packet mark 0x10000).
+	#
+	# This ensures that pre-CPD connectivity checks (e.g. www.google.com/generate_204) are
+	# still blocked, so captive portal detection works correctly.
+	#
+	# Use Case Example:
+	# A captive portal with advertisement pages containing Google Maps embeds. The Walled Garden
+	# cannot be used because whitelisting Google domains would defeat Android CPD. Instead, use
+	# preauthenticated_fqdn_list to allow maps access only after CPD has already triggered.
+	#
+	# This requires the dnsmasq-full package to be installed.
+	#
+	# Configuration format is the same as walledgarden:
+	#
+	# list preauthenticated_fqdn_list 'fqdn1 fqdn2 fqdn3 .... fqdnN'
+	# list preauthenticated_port_list 'port1 port2 port3 .... portN'
+	#
+	# Note: If preauthenticated_port_list is NOT specified, then access is granted
+	# for all protocols (tcp, udp) on ALL ports for each fqdn specified in preauthenticated_fqdn_list.
+	#
+	# Note: If preauthenticated_port_list IS specified, then:
+	#  1. Specified port numbers apply to ALL FQDN's specified in preauthenticated_fqdn_list.
+	#  2. Only tcp protocol access is granted for specified ports.
+	#
+	# Example - Allow Google Maps access for preauthenticated users:
+	# 	list preauthenticated_fqdn_list 'maps.google.com maps.googleapis.com maps.gstatic.com www.google.com'
+	# 	list preauthenticated_port_list '443'
+	#
+	# WARNING: Do not add CPD detection domains (connectivitycheck.gstatic.com,
+	# connectivitycheck.android.com, captive.apple.com, www.msftconnecttest.com) as this
+	# would defeat captive portal detection for preauthenticated clients.
+
+	###########################################################################################
+
+	#####
 	# Block Lists
 	# Deny authenticated users access to external services
 	# This is commonly referred to as a Block List.

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -132,6 +132,8 @@ _client_list_append(const char mac[], const char ip[])
 		client->fw_connection_state = FW_MARK_TRUSTED;
 	} else {
 		client->fw_connection_state = FW_MARK_PREAUTHENTICATED;
+		// Set preauthenticated mark in nftables for conditional FQDN access
+		iptables_fw_preauthenticate(client);
 	}
 
 	client->id = client_id;

--- a/src/conf.c
+++ b/src/conf.c
@@ -277,6 +277,7 @@ config_init(int argc, char **argv)
 	sscanf(set_option_str("fw_mark_authenticated", DEFAULT_FW_MARK_AUTHENTICATED, debug_level), "%x", &config.fw_mark_authenticated);
 	sscanf(set_option_str("fw_mark_auth_blocked", DEFAULT_FW_MARK_AUTH_BLOCKED, debug_level), "%x", &config.fw_mark_auth_blocked);
 	sscanf(set_option_str("fw_mark_trusted", DEFAULT_FW_MARK_TRUSTED, debug_level), "%x", &config.fw_mark_trusted);
+	sscanf(set_option_str("fw_mark_preauthenticated", DEFAULT_FW_MARK_PREAUTHENTICATED, debug_level), "%x", &config.fw_mark_preauthenticated);
 
 	// config.ip6 = DEFAULT_IP6;
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -102,6 +102,7 @@
 #define DEFAULT_FW_MARK_AUTH_BLOCKED "0x30001"
 #define DEFAULT_AUTHENTICATION_MARK "0x00030000"
 #define DEFAULT_FW_MARK_TRUSTED "0x20000"
+#define DEFAULT_FW_MARK_PREAUTHENTICATED "0x10000"
 #define DEFAULT_THEMESPEC_PATH ""
 #define DEFAULT_FAS_REMOTEFQDN "disabled"
 #define DEFAULT_FAS_REMOTEIP "disabled"
@@ -271,6 +272,7 @@ typedef struct {
 	unsigned int fw_mark_auth_blocked;			//@brief nftables mark for auth_blocked packets
 	char *authentication_mark;				//@brief Padded authentication mark
 	unsigned int fw_mark_trusted;				//@brief nftables mark for trusted packets
+	unsigned int fw_mark_preauthenticated;			//@brief nftables mark for preauthenticated packets (post-CPD, pre-auth)
 	int ip6;						//@brief enable IPv6
 	char *binauth;						//@brief external postauthentication program
 	char *custombinauth;					//@brief external custom postauthentication program

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -52,7 +52,7 @@
 static int _iptables_init_marks(void);
 
 // Used to mark packets, and characterize client state.  Unmarked packets are considered 'preauthenticated'
-unsigned int FW_MARK_PREAUTHENTICATED;	// @brief 0: Actually not used as a packet mark
+unsigned int FW_MARK_PREAUTHENTICATED;	// @brief The client is preauthenticated (post-CPD, pre-auth)
 unsigned int FW_MARK_AUTHENTICATED;	// @brief The client is authenticated
 unsigned int FW_MARK_AUTH_BLOCKED;	// @brief The client is authenticated
 unsigned int FW_MARK_TRUSTED;		// @brief The client is trusted
@@ -101,8 +101,10 @@ _iptables_init_marks()
 		return -1;
 	}
 
-	FW_MARK_PREAUTHENTICATED = 0;  // always 0
-	// FW_MARK_MASK is bitwise OR of other marks
+	FW_MARK_PREAUTHENTICATED = config->fw_mark_preauthenticated;
+	// FW_MARK_MASK is bitwise OR of other marks (does NOT include preauthenticated)
+	// Preauthenticated mark uses an independent bit position so existing
+	// trusted/authenticated checks are unaffected
 	FW_MARK_MASK = FW_MARK_TRUSTED | FW_MARK_AUTHENTICATED;
 
 	debug(LOG_DEBUG,"nftables mark %s: 0x%x",
@@ -667,11 +669,34 @@ iptables_upload_ratelimit_enable(t_client *client, int enable)
 
 // Insert or delete firewall mangle rules marking a client's packets.
 int
+iptables_fw_preauthenticate(t_client *client)
+{
+	int rc = 0;
+
+	if (FW_MARK_PREAUTHENTICATED == 0) {
+		return 0;  // Preauthenticated marking disabled (legacy behavior)
+	}
+
+	debug(LOG_NOTICE, "Preauthenticating %s %s", client->ip, client->mac);
+
+	// Set the preauthenticated mark on outgoing packets from this client.
+	// This allows mark-conditional preauthenticated nftset rules to match.
+	rc |= nftables_do_command("insert rule inet nds_mangle %s ip saddr %s ether saddr %s counter meta mark set mark or 0x%x", CHAIN_OUTGOING, client->ip, client->mac, FW_MARK_PREAUTHENTICATED);
+
+	return rc;
+}
+
+int
 iptables_fw_authenticate(t_client *client)
 {
 	int rc = 0;
 
 	debug(LOG_NOTICE, "Authenticating %s %s", client->ip, client->mac);
+
+	// Remove preauthenticated mark rule if present (client is upgrading to authenticated)
+	if (FW_MARK_PREAUTHENTICATED != 0) {
+		execute("/usr/lib/opennds/libopennds.sh delete_client_rule nds_mangle \"%s\" all \"%s\"", CHAIN_OUTGOING, client->ip);
+	}
 
 	// This rule is for marking upload (outgoing) packets, and for upload byte accounting. Drop all bucket overflow packets
 	rc |= nftables_do_command("insert rule inet nds_mangle %s ip saddr %s ether saddr %s counter meta mark set mark or 0x%x", CHAIN_OUTGOING, client->ip, client->mac, FW_MARK_AUTHENTICATED);

--- a/src/fw_iptables.h
+++ b/src/fw_iptables.h
@@ -53,7 +53,7 @@
 
 
 /** Used to mark packets, and characterize client state.  Unmarked packets are considered 'preauthenticated' */
-extern unsigned int  FW_MARK_PREAUTHENTICATED;	/**< @brief 0: Actually not used as a packet mark */
+extern unsigned int  FW_MARK_PREAUTHENTICATED;	/**< @brief The client is preauthenticated (post-CPD, pre-auth) */
 extern unsigned int  FW_MARK_AUTHENTICATED;	/**< @brief The client is authenticated */
 extern unsigned int  FW_MARK_AUTH_BLOCKED;	/**< @brief The client is authenticated but blocked */
 extern unsigned int  FW_MARK_TRUSTED;		/**< @brief The client is trusted */
@@ -71,6 +71,7 @@ int create_client_ruleset(char rulesetname[], char ruleset[]);
 
 /** @brief Define the access of a specific client */
 int iptables_fw_authenticate(t_client *client);
+int iptables_fw_preauthenticate(t_client *client);
 int iptables_fw_deauthenticate(t_client *client);
 
 /** @brief Enable/Disable Upload Rate Limiting of a specific client */

--- a/src/main.c
+++ b/src/main.c
@@ -197,6 +197,11 @@ termination_handler(int s)
 	execute_ret_url_encoded(msg, SMALL_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset delete walledgarden");
 	free(msg);
 
+	// If Preauthenticated nftset exists, destroy it.
+	msg = safe_calloc(SMALL_BUF);
+	execute_ret_url_encoded(msg, SMALL_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset delete preauthenticated");
+	free(msg);
+
 	// If Block List nftset exists, destroy it.
 	msg = safe_calloc(SMALL_BUF);
 	execute_ret_url_encoded(msg, SMALL_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset delete blocklist");
@@ -862,6 +867,10 @@ setup_from_config(void)
 	free(msg);
 
 	msg = safe_calloc(SMALL_BUF);
+	execute_ret_url_encoded(msg, SMALL_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset delete preauthenticated");
+	free(msg);
+
+	msg = safe_calloc(SMALL_BUF);
 	execute_ret_url_encoded(msg, SMALL_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset delete blocklist");
 	free(msg);
 
@@ -871,6 +880,15 @@ setup_from_config(void)
 
 	if (execute_ret_url_encoded(msg, STATUS_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset insert walledgarden") == 0) {
 		debug(LOG_INFO, "Walled Garden Setup Request sent");
+	}
+
+	free(msg);
+
+	// Set up the Preauthenticated FQDN list
+	msg = safe_calloc(SMALL_BUF);
+
+	if (execute_ret_url_encoded(msg, STATUS_BUF - 1, "/usr/lib/opennds/libopennds.sh nftset insert preauthenticated") == 0) {
+		debug(LOG_INFO, "Preauthenticated FQDN List Setup Request sent");
 	}
 
 	free(msg);


### PR DESCRIPTION
## Summary

Add `preauthenticated_fqdn_list` and `preauthenticated_port_list` configuration options allowing specific domains to be accessible to clients in the **preauthenticated** state (post-CPD, pre-authentication) without breaking Captive Portal Detection (CPD).

## Problem

FAS deployments commonly serve ad pages, payment forms, or informational content that need external resources (Google Maps embeds, CDN assets, etc.) before granting full internet access. The only current mechanism — **walledgarden** — uses unconditional rules that match ALL clients, including those that haven't yet triggered CPD:

```
ip daddr @walledgarden accept    ← matches ALL clients, including pre-CPD
```

Adding domains like `www.google.com` to the walledgarden breaks Android CPD, because some Android devices use `www.google.com/generate_204` as a secondary connectivity check. When reachable before CPD triggers, the device never shows "Sign in required".

## Solution

Use nftables marks to make preauthenticated domain access **conditional** on client state:

1. **Activate `FW_MARK_PREAUTHENTICATED` (0x10000)** — previously declared but unused
2. **Add `iptables_fw_preauthenticate()`** — sets mark when client enters preauthenticated state
3. **Mark-conditional nftset rules** — `meta mark & 0x10000 == 0x10000 ip daddr @preauthenticated accept`
4. **Clean up** preauth mark during authentication transition

Pre-CPD devices have no mark → preauthenticated domains blocked → CPD works correctly.
Post-CPD devices get `0x10000` mark → preauthenticated domains accessible.

### Mark Architecture

```
FW_MARK_PREAUTHENTICATED = 0x00010000  (bit 16, independent)
FW_MARK_TRUSTED          = 0x00020000  (bit 17)
FW_MARK_AUTHENTICATED    = 0x00030000  (bits 16+17)
FW_MARK_MASK             = 0x00030000  (unchanged — does NOT include preauthenticated)
```

The preauthenticated mark uses an independent bit position outside `FW_MARK_MASK`, so existing trusted/authenticated logic is completely unaffected.

## Configuration

```
# /etc/config/opennds
list preauthenticated_fqdn_list 'maps.google.com maps.googleapis.com maps.gstatic.com www.google.com'
list preauthenticated_port_list '443'
```

Format is identical to `walledgarden_fqdn_list` / `walledgarden_port_list`.

## Files Changed (9 files)

| File | Change |
|------|--------|
| `ChangeLog` | Document new feature |
| `forward_authentication_service/libs/libopennds.sh` | Add "preauthenticated" to nftset dispatcher + mark-conditional rules |
| `linux_openwrt/opennds/files/etc/config/opennds` | Document new config options with examples |
| `src/client_list.c` | Call `iptables_fw_preauthenticate()` when client enters preauth state |
| `src/conf.c` | Read `fw_mark_preauthenticated` config |
| `src/conf.h` | Add `DEFAULT_FW_MARK_PREAUTHENTICATED` and config struct member |
| `src/fw_iptables.c` | Activate preauth mark, add `iptables_fw_preauthenticate()`, clean up mark on auth |
| `src/fw_iptables.h` | Declare `iptables_fw_preauthenticate()`, update comment |
| `src/main.c` | Add preauthenticated nftset lifecycle (cleanup/setup) |

## Test Results

Tested on OpenWrt 24.10, OpenNDS 10.3.1, Samsung Galaxy A16 5G:

| Test | Result |
|------|--------|
| Fresh device connects, no mark set | CPD triggers correctly |
| `www.google.com` in walledgarden (unconditional) | **CPD BROKEN** on Android |
| `www.google.com` in preauthenticated list, client has 0x10000 mark | CPD works, maps load |
| `www.google.com` in preauthenticated list, client has no mark (pre-CPD) | CPD works, maps blocked |
| Client authenticates (mark → 0x30000) | Full internet via ndsAUT chain |
| Client deauthenticates | All mangle rules removed |

## Backward Compatibility

- No changes to walledgarden, blocklist, or authentication behavior
- New config options are optional; omitting them produces identical behavior to current
- `FW_MARK_PREAUTHENTICATED` was declared but unused; activating it uses a bit outside `FW_MARK_MASK`
- Existing FAS deployments work unchanged